### PR TITLE
Fix NATTEN signature mismatch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ einops
 tqdm
 wandb
 ninja
-natten
+natten>=0.14.6
 hydra-core
 joblib
 dill


### PR DESCRIPTION
NATTEN functions take in kernel size as well as dilation since 0.14.6. The change in signature breaks Hydra-NA, which calls those functions directly instead of using the nn.Module.

This fixes #8 .

Refs:

* https://github.com/SHI-Labs/NATTEN/releases/tag/v0.14.6
* https://github.com/SHI-Labs/NATTEN/blob/main/CHANGELOG.md#0146---2023-03-21

Same change in other repositories using NATTEN:
* https://github.com/huggingface/transformers/pull/22229
* https://github.com/huggingface/transformers/pull/22298